### PR TITLE
adds working dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM golang:1.7.1-onbuild
 MAINTAINER Jimmy Mesta "jimmy.mesta@gmail.com"
 
-RUN wget https://dl.eff.org/certbot-auto -P /usr/local/sbin && \
-    chmod a+x /usr/local/sbin/certbot-auto && \
-    git clone https://github.com/rawdigits/go-flashpaper
+RUN git clone https://github.com/rawdigits/go-flashpaper
 
 WORKDIR go-flashpaper
 RUN go build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.7.1-onbuild
+MAINTAINER Jimmy Mesta "jimmy.mesta@gmail.com"
+
+RUN wget https://dl.eff.org/certbot-auto -P /usr/local/sbin && \
+    chmod a+x /usr/local/sbin/certbot-auto && \
+    git clone https://github.com/rawdigits/go-flashpaper
+
+WORKDIR go-flashpaper
+RUN go build
+
+RUN openssl req \
+    -new \
+    -newkey rsa:4096 \
+    -days 365 \
+    -nodes \
+    -x509 \
+    -subj "/C=US/ST=Denial/L=DockerLand/O=Dis/CN=www.flashpaper.com" \
+    -keyout /go/src/app/go-flashpaper/server.key \
+    -out /go/src/app/go-flashpaper/server.crt
+
+EXPOSE 8443
+
+ENTRYPOINT ["./go-flashpaper"] 


### PR DESCRIPTION
Created simple Dockerfile to run go-flashpaper in a container. To build run `docker build . -t test/flashpaper` and run using `docker run -d -p 8443:8443 test/flashpaper`. The service will then be available locally at https://127.0.0.1:8443 if you are running Docker for Mac. A self-signed certificate is used for TLS.
