### PR TITLE
Use sendmail to email multiple people unique links

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Q: *Why doesn't it have (feature x)?*
 
 A: Because. Also it never will.
 
+Q: *Why is mail not being delivered?*
+
+A: You might have outbound firewall rules on the host where this is deployed that prevent `sendmail` from doing its job. You could have deployed this on a host that somehow got really bad sender reputation. Or your `sendmail` is broken somehow (unlikely.)
+
 ## What are some examples of using this?
 
 ### Example 1
@@ -63,4 +67,13 @@ A: Because. Also it never will.
 
 **Bob**: Yay!
 
+### Example 4
+
+**Alice**: Hi team, here is the new shared Photobucket password. Check your inboxes for the link to see it!
+
+**Bob**: Yay!
+
+**Carol**: Yay!
+
+**Dave**: I hope we don't get banned again.
 ## Have a nice day!


### PR DESCRIPTION
The IR team I work on has a problem where we're constantly dealing with
silly people putting passwords in JIRA or ServiceNow. Usually this
happens because there's a shared account with a rotating password, or
maybe a client has given a certain team FTP creds (no comment on the use
of FTP.)

It's a bit painful to use `go-flashpaper` for this case because you have
to make a new secret for each team member who needs the file, so this
way you can just put in a list of recipients.

The one caveat of my approach is that in order to keep things
lightweight I use the local MTA (`sendmail`) to send mail. In most
environments that should be fine - I also tested this by spinning up a
fresh EC2 t2.micro w/ Amazon Linux and `sendmail`ing to my personal
address - but there's definitely going to be cases where you deploy this on a
box that has outbound firewall rules preventing mail from being
delivered.

At the very least, I can confirm that a random EC2 public DNS entry has
a good enough sender reputation to deliver to my personal Gmail inbox,
which should suffice for most ragtag orgs.
