### PR TITLE
Add "Deploy to Heroku" Option

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: flashpaper 

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: flashpaper 
+web: go-flashpaper 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ It is a web service that allows you to upload text snippets or files and generat
 6. Run go-flashpaper: `./go-flashpaper`
 7. Connect to the web service via `https://yourserver.example.com:8443` (note: 8443 is the default port, so no one has an excuse to run this as root)
 8. Share secret things.
+
+## Deploy to Heroku
+
+go-flashpaper works on Heroku
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/staaldraad/go-flashpaper)
  
 ## FAQ
 

--- a/app.json
+++ b/app.json
@@ -2,5 +2,11 @@
   "name": "go-flashpaper on Heroku",
   "description": "Runs rawdigits/go-flashpaper on Heroku",
   "repository": "https://github.com/staaldraad/go-flashpaper",
-  "keywords": ["flashpaper", "pew"]
+  "keywords": ["flashpaper", "pew"],
+  "env": {
+      "HEROKU":{
+        "description": "If we are running on Heroku",
+        "value": "TRUE"
+      }
+  }
 }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,6 @@
+{
+  "name": "go-flashpaper on Heroku",
+  "description": "Runs rawdigits/go-flashpaper on Heroku",
+  "repository": "https://github.com/staaldraad/go-flashpaper",
+  "keywords": ["flashpaper", "pew"]
+}

--- a/flashpaper.go
+++ b/flashpaper.go
@@ -213,16 +213,14 @@ func main() {
 	//run this without TLS if you have taken leave of your senses.
 	//err := http.ListenAndServe(":8080", nil)
     PORT := os.Getenv("PORT")
-    heroku := true
 
     if PORT == "" {
         PORT = "8443"
-        heroku = false
     }
 
     var err error
 
-    if heroku {
+    if os.Getenv("HEROKU") == "TRUE" {
 	    err = http.ListenAndServe(fmt.Sprintf(":%s",PORT), nil)
     } else {
         err = http.ListenAndServeTLS(fmt.Sprintf(":%s",PORT), "server.crt", "server.key", nil)

--- a/flashpaper.go
+++ b/flashpaper.go
@@ -140,7 +140,7 @@ func shareable(id string, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
 	proto := "https"
-	if r.TLS == nil {
+	if r.TLS == nil && os.Getenv("HEROKU") != "TRUE" {
 		proto = "http"
 	}
 	ret := fmt.Sprintf(lackofstyle+shareform+endofstyle, proto, r.Host, id, MAXHOURSTOKEEP)

--- a/flashpaper.go
+++ b/flashpaper.go
@@ -213,12 +213,21 @@ func main() {
 	//run this without TLS if you have taken leave of your senses.
 	//err := http.ListenAndServe(":8080", nil)
     PORT := os.Getenv("PORT")
+    heroku := true
+
     if PORT == "" {
         PORT = "8443"
+        heroku = false
     }
 
-    //err := http.ListenAndServeTLS(fmt.Sprintf(":%d",PORT), "server.crt", "server.key", nil)
-	err := http.ListenAndServe(fmt.Sprintf(":%s",PORT), nil)
+    var err error
+
+    if heroku {
+	    err = http.ListenAndServe(fmt.Sprintf(":%s",PORT), nil)
+    } else {
+        err = http.ListenAndServeTLS(fmt.Sprintf(":%s",PORT), "server.crt", "server.key", nil)
+    }
+
 	if err != nil {
 		fmt.Printf("main(): %s\n", err)
 		fmt.Printf("Errors usually mean you don't have the required server.crt or server.key files.\n")

--- a/flashpaper.go
+++ b/flashpaper.go
@@ -11,7 +11,7 @@ import (
 	"io"
 	"log"
 	"net/http"
-    "os"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -212,19 +212,19 @@ func main() {
 	//You can uncomment the non TLS version of ListenAndServe and
 	//run this without TLS if you have taken leave of your senses.
 	//err := http.ListenAndServe(":8080", nil)
-    PORT := os.Getenv("PORT")
+	PORT := os.Getenv("PORT")
 
-    if PORT == "" {
-        PORT = "8443"
-    }
+	if PORT == "" {
+		PORT = "8443"
+	}
 
-    var err error
+	var err error
 
-    if os.Getenv("HEROKU") == "TRUE" {
-	    err = http.ListenAndServe(fmt.Sprintf(":%s",PORT), nil)
-    } else {
-        err = http.ListenAndServeTLS(fmt.Sprintf(":%s",PORT), "server.crt", "server.key", nil)
-    }
+	if os.Getenv("HEROKU") == "TRUE" {
+		err = http.ListenAndServe(fmt.Sprintf(":%s", PORT), nil)
+	} else {
+		err = http.ListenAndServeTLS(fmt.Sprintf(":%s", PORT), "server.crt", "server.key", nil)
+	}
 
 	if err != nil {
 		fmt.Printf("main(): %s\n", err)

--- a/flashpaper.go
+++ b/flashpaper.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+    "os"
 	"strings"
 	"sync"
 	"time"
@@ -211,7 +212,13 @@ func main() {
 	//You can uncomment the non TLS version of ListenAndServe and
 	//run this without TLS if you have taken leave of your senses.
 	//err := http.ListenAndServe(":8080", nil)
-	err := http.ListenAndServeTLS(":8443", "server.crt", "server.key", nil)
+    PORT := os.Getenv("PORT")
+    if PORT == "" {
+        PORT = "8443"
+    }
+
+    //err := http.ListenAndServeTLS(fmt.Sprintf(":%d",PORT), "server.crt", "server.key", nil)
+	err := http.ListenAndServe(fmt.Sprintf(":%s",PORT), nil)
 	if err != nil {
 		fmt.Printf("main(): %s\n", err)
 		fmt.Printf("Errors usually mean you don't have the required server.crt or server.key files.\n")

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,6 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [],
+	"rootPath": "github.com/staaldraad/go-flashpaper"
+}


### PR DESCRIPTION
## What 
This adds the necessary files and reads some environmental variables, allowing go-flashpaper to run on Heroku. 

## Why
A one-click deploy to Heroku is useful to get a go-flashpaper instance up and running. Bonus, it comes with free TLS

## Changes

Adds:
* app.json
* Procfile
* vendor/

Modifies:
* flashpaper.go

The base functionality is the same and go-flashpaper will run as before. However, using the Deploy to Heroku button creates a go-flashpaper instance on Heroku. The instance is configured through environment variables. 

`PORT` - this is used to set the listening port (primarily in Heroku, but can be used in stand-alone mode as well)
`HEROKU` - indicates that we are running in Heroku. There are probably better ways of doing this.


### Additional Info

The "Deploy to Heroku" button currently points to my fork at github.com/staaldraad/go-flashpaper. It is probably worth modifying it here to point to this repository.